### PR TITLE
RC v1.5-beta compatibility

### DIFF
--- a/identity_smtp.php
+++ b/identity_smtp.php
@@ -121,7 +121,8 @@ class identity_smtp extends rcube_plugin
     function identityFormWillBeDisplayed($args)
     {
         $form   = $args['form'];
-        $record = $args['record'];
+        $record = isset($args['record']) ? $args['record'] : [];
+
 
         // Load the stored smtp settings
         $smtpSettingsRecord = $this->loadSmtpSettings($record);


### PR DESCRIPTION
in RC 1.5-beta `$record` comes as `null` instead of `{ email: null }` and this breaks "Create Identity" screen. This fixes the issue.