### PR TITLE
Add support for RC 1.6

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,23 +4,18 @@ identity_smtp Roundcube Plugin
 This roundcube plugin allows to setup identities with different smtp servers
 than the servers default.
 
+
 Installation
 ============
 
-This plugin is available in the [Roundcube Plugin
-repository](http://plugins.roundcube.net/packages/elm/identity_smtp).
-
-Manual Installation
--------------------
-
     $ cd /path/to/roundcube/plugins
-    $ git clone git://github.com/elm/Roundcube-SMTP-per-Identity-Plugin.git identity_smtp
+    $ git clone https://github.com/CocytusServices/Roundcube-Identity-SMTP identity_smtp
 
 The plugins folder must be named identity_smtp.
 
 Add `identity_smtp` to `$rcmail_config['plugins']` in `config/main.inc.php`.
 
-A default smtp server has to be set in `config/main.inc.php`. Otherwise
+A default smtp host has to be set in `config/main.inc.php`. Otherwise
 roundcube will not call any smtp function and the plugin will not work.
 
 Usage
@@ -32,11 +27,6 @@ to use to send a mail.
 Examples
 --------
 ### Gmail
-* Server IP/Hostname: tls://smtp.gmail.com
-* Server Port: 587
+* Server Host: tls://smtp.gmail.com:587
 * Username: example@gmail.com
-* Password: ...
-
-Contact
-=======
-You can contact me at elm -at- skweez.net
+* Password: CompletelySecurePassword

--- a/README.markdown
+++ b/README.markdown
@@ -15,7 +15,7 @@ Manual Installation
 -------------------
 
     $ cd /path/to/roundcube/plugins
-    $ git clone https://github.com/CocytusServices/Roundcube-Identity-SMTP identity_smtp
+    $ git clone https://github.com/deflomu/Roundcube-Identity-SMTP identity_smtp
 
 The plugins folder must be named identity_smtp.
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "cocytus/identity_smtp",
+    "name": "elm/identity_smtp",
     "description": "Individual SMTP settings for every identity",
     "keywords": ["mail","smtp","settings","identity"],
-    "homepage": "https://github.com/elm/Roundcube-SMTP-per-Identity-Plugin",
+    "homepage": "https://github.com/deflomu/Roundcube-SMTP-per-Identity-Plugin",
     "type": "roundcube-plugin",
     "license": "MIT",
     "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "elm/identity_smtp",
+    "name": "cocytus/identity_smtp",
     "description": "Individual SMTP settings for every identity",
     "keywords": ["mail","smtp","settings","identity"],
     "homepage": "https://github.com/elm/Roundcube-SMTP-per-Identity-Plugin",

--- a/identity_smtp.php
+++ b/identity_smtp.php
@@ -81,8 +81,7 @@ class identity_smtp extends rcube_plugin
 
         $smtpSettingsRecord = array(
             'smtp_standard' => isset($smtp_standard),
-            'smtp_server' => rcube_utils::get_input_value('_smtp_server', rcube_utils::INPUT_POST),
-            'smtp_port' => rcube_utils::get_input_value('_smtp_port', rcube_utils::INPUT_POST),
+            'smtp_host' => rcube_utils::get_input_value('_smtp_host', rcube_utils::INPUT_POST),
             'smtp_user' => rcube_utils::get_input_value('_smtp_user', rcube_utils::INPUT_POST),
             'smtp_pass' => $password
         );
@@ -104,8 +103,7 @@ class identity_smtp extends rcube_plugin
         $id                 = intval($args['identity_id']);
         $smtpSettingsRecord = array(
             'smtp_standard' => $smtpSettings[$id]['smtp_standard'],
-            'smtp_server' => $smtpSettings[$id]['smtp_server'],
-            'smtp_port' => $smtpSettings[$id]['smtp_port'],
+            'smtp_host' => $smtpSettings[$id]['smtp_host'],
             'smtp_user' => $smtpSettings[$id]['smtp_user'],
             'smtp_pass' => $smtpSettings[$id]['smtp_pass'],
             'smtp_pass2' => $smtpSettings[$id]['smtp_pass']
@@ -149,16 +147,11 @@ class identity_smtp extends rcube_plugin
                             'label' => $this->gettext('use_default_smtp_server'),
                             'onclick' => 'identity_smtp_toggle_standard_server()'
                         ),
-                        'smtp_server' => array(
+                        'smtp_host' => array(
                             'type' => 'text',
-                            'label' => $this->gettext('smtp_server'),
+                            'label' => $this->gettext('smtp_host'),
                             'class' => 'identity_smtp_form',
                             'size' => 40
-                        ),
-                        'smtp_port' => array(
-                            'type' => 'text',
-                            'label' => $this->gettext('smtp_port'),
-                            'class' => 'identity_smtp_form'
                         ),
                         'smtp_user' => array(
                             'type' => 'text',
@@ -245,8 +238,7 @@ class identity_smtp extends rcube_plugin
             'identity_id' => $this->from_identity
         ));
         if (!$smtpSettings['smtp_standard'] && !is_null($smtpSettings['smtp_standard'])) {
-            $args['smtp_server'] = $smtpSettings['smtp_server'];
-            $args['smtp_port']   = $smtpSettings['smtp_port'];
+            $args['smtp_host']   = $smtpSettings['smtp_host'];
             $args['smtp_user']   = $smtpSettings['smtp_user'];
             $args['smtp_pass']   = rcmail::get_instance()->decrypt($smtpSettings['smtp_pass']);
         }

--- a/localization/ca_ES.inc
+++ b/localization/ca_ES.inc
@@ -3,8 +3,7 @@
 $labels = array();
 $labels['smtp_settings_header'] = 'Configuració SMTP';
 $labels['use_default_smtp_server'] = 'Utilitza el servidor SMTP per defecte';
-$labels['smtp_server'] = 'IP/Nom Servidor';
-$labels['smtp_port'] = 'Port Servidor';
+$labels['smtp_host'] = 'IP/Nom + Port Servidor';
 $labels['smtp_user'] = 'Nom Usuari';
 $labels['smtp_pass'] = 'Contrassenya';
 $labels['smtp_pass2'] = 'Repeteix la contrassenya';

--- a/localization/de_DE.inc
+++ b/localization/de_DE.inc
@@ -3,8 +3,7 @@
 $labels = array();
 $labels['smtp_settings_header'] = 'SMTP Einstellungen';
 $labels['use_default_smtp_server'] = 'Den voreingestellten SMTP Server verwenden';
-$labels['smtp_server'] = 'Server IP/Hostname. (Für Verschlüsselung Präfix ssl:// oder tls:// nutzen)';
-$labels['smtp_port'] = 'Server Port';
+$labels['smtp_server'] = 'Server IP/Hostname + Port (Für Verschlüsselung Präfix ssl:// oder tls:// nutzen)';
 $labels['smtp_user'] = 'Benutzername';
 $labels['smtp_pass'] = 'Passwort';
 $labels['smtp_pass2'] = 'Passwort wiederholen';

--- a/localization/en_US.inc
+++ b/localization/en_US.inc
@@ -3,8 +3,7 @@
 $labels = array();
 $labels['smtp_settings_header'] = 'SMTP Settings';
 $labels['use_default_smtp_server'] = 'Use the default SMTP server';
-$labels['smtp_server'] = 'Server IP/Hostname (For encryption use prefix ssl:// or tls://)';
-$labels['smtp_port'] = 'Server Port';
+$labels['smtp_host'] = 'Server IP/Hostname + Port (For encryption use prefix ssl:// or tls://)';
 $labels['smtp_user'] = 'Username';
 $labels['smtp_pass'] = 'Password';
 $labels['smtp_pass2'] = 'Repeat Password';

--- a/localization/es_ES.inc
+++ b/localization/es_ES.inc
@@ -3,8 +3,7 @@
 $labels = array();
 $labels['smtp_settings_header'] = 'Configuración SMTP';
 $labels['use_default_smtp_server'] = 'Utiliza el servidor SMTP por defecto';
-$labels['smtp_server'] = 'IP/Nombre Servidor';
-$labels['smtp_port'] = 'Puerto Servidor';
+$labels['smtp_server'] = 'IP/Nombre + Puerto Servidor';
 $labels['smtp_user'] = 'Nombre Usuario';
 $labels['smtp_pass'] = 'Contraseña';
 $labels['smtp_pass2'] = 'Repite la contraseña';

--- a/localization/fr_FR.inc
+++ b/localization/fr_FR.inc
@@ -3,8 +3,7 @@
 $labels = array();
 $labels['smtp_settings_header'] = 'Paramètres SMTP';
 $labels['use_default_smtp_server'] = 'Utiliser le serveur SMTP par défaut';
-$labels['smtp_server'] = 'IP du serveur / Nom de l\'hôte';
-$labels['smtp_port'] = 'Port du serveur';
+$labels['smtp_server'] = 'IP du serveur / Nom de l\'hôte + Port du serveur';
 $labels['smtp_user'] = 'Nom d\'utilisateur';
 $labels['smtp_pass'] = 'Mot de passe';
 $labels['smtp_pass2'] = 'Répéter le mot de passe';


### PR DESCRIPTION
This updates the variables supplied to match the new format (`smtp_host` instead of `smtp_server` + `smtp_port`)
There is also a crude translation included for all languages except for JP