### PR TITLE
Don't use data from non-existing identity to work with custom_from plugin

### DIFF
--- a/identity_smtp.php
+++ b/identity_smtp.php
@@ -238,7 +238,7 @@ class identity_smtp extends rcube_plugin
         $smtpSettings = $this->loadSmtpSettings(array(
             'identity_id' => $this->from_identity
         ));
-        if (!$smtpSettings['smtp_standard'] && !is_null($smtpSettings['smtp_standard'])) {
+        if (!is_null($this->from_identity) && !$smtpSettings['smtp_standard'] && !is_null($smtpSettings['smtp_standard'])) {
             $args['smtp_host']   = $smtpSettings['smtp_host'];
             $args['smtp_user']   = $smtpSettings['smtp_user'];
             $args['smtp_pass']   = rcmail::get_instance()->decrypt($smtpSettings['smtp_pass']);


### PR DESCRIPTION
Allows to use custom_from plugin. The patch is minimalistic to prevent using wrong data. Could be improved (i.e. don't call the function above at all), but it works as is and the chance of bad side effects is much smaller this way.